### PR TITLE
go-uuid moved to github

### DIFF
--- a/server/handler/api_users.go
+++ b/server/handler/api_users.go
@@ -1,13 +1,13 @@
 package handler
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/json"
 	"github.com/MerlinDMC/dsapid"
 	"github.com/MerlinDMC/dsapid/server/middleware"
 	"github.com/MerlinDMC/dsapid/storage"
 	log "github.com/MerlinDMC/logrus"
 	"github.com/go-martini/martini"
+	"github.com/pborman/uuid"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/storage/manifest_storage.go
+++ b/storage/manifest_storage.go
@@ -1,9 +1,9 @@
 package storage
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/json"
 	"github.com/MerlinDMC/dsapid"
+	"github.com/pborman/uuid"
 	"io/ioutil"
 	"os"
 	"path"


### PR DESCRIPTION
Fixes a build issue:

```
package code.google.com/p/go-uuid/uuid: unable to detect version control system for code.google.com/ path
```
